### PR TITLE
Add Python 3 support

### DIFF
--- a/guacapy/__init__.py
+++ b/guacapy/__init__.py
@@ -1,2 +1,7 @@
-from client import Guacamole
-from templates import *
+import sys
+if sys.version_info[0] < 3:
+    from client import Guacamole
+    from templates import *
+else:
+    from .client import Guacamole
+    from .templates import *

--- a/guacapy/__init__.py
+++ b/guacapy/__init__.py
@@ -1,7 +1,2 @@
-import sys
-if sys.version_info[0] < 3:
-    from client import Guacamole
-    from templates import *
-else:
-    from .client import Guacamole
-    from .templates import *
+from guacapy.client import Guacamole
+from guacapy.templates import *


### PR DESCRIPTION
This should be a fix for #15.

I did a simple python version check, so if the version number is less than 3, I run the imports the way they currently are. Otherwise, it uses relative dot imports.