### PR TITLE
Do not hard-set logging level inside the lib

### DIFF
--- a/guacapy/client.py
+++ b/guacapy/client.py
@@ -9,7 +9,6 @@ import re
 import requests
 
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Do not hard-set logging root logger level inside the lib. Let the client set it.