### PR TITLE
catch missing values for the URL path and assume that it's /

### DIFF
--- a/guacapy/client.py
+++ b/guacapy/client.py
@@ -669,3 +669,13 @@ class Guacamole:
             payload=payload,
             json_response=False,
         )
+
+    def get_group_permissions(self, groupname, datasource=None):
+        if not datasource:
+            datasource = self.primary_datasource
+        return self.__auth_request(
+            method="GET",
+            url="{}/session/data/{}/userGroups/{}/permissions".format(
+                self.REST_API, datasource, groupname
+            ),
+        )

--- a/guacapy/client.py
+++ b/guacapy/client.py
@@ -46,8 +46,8 @@ class Guacamole:
     ):
         if method.lower() not in ["https", "http"]:
             raise ValueError("Only http and https methods are valid.")
-        if url_path is None or not url_path:
-            url_path = '/'
+        if not url_path:
+            url_path = "/"
         self.REST_API = "{}://{}{}/api".format(method, hostname, url_path)
         self.username = username
         self.password = password

--- a/guacapy/client.py
+++ b/guacapy/client.py
@@ -46,6 +46,8 @@ class Guacamole:
     ):
         if method.lower() not in ["https", "http"]:
             raise ValueError("Only http and https methods are valid.")
+        if url_path is None or not url_path:
+            url_path = '/'
         self.REST_API = "{}://{}{}/api".format(method, hostname, url_path)
         self.username = username
         self.password = password


### PR DESCRIPTION
When using like urllib3 to break up a URL into the components required to instantiate the class, omitting the trailing / of the URL will result in failure due to None being passed in.  We should be able to assume that no path is the root path.