### PR TITLE
add get_connection_group_connections method

### DIFF
--- a/guacapy/client.py
+++ b/guacapy/client.py
@@ -131,6 +131,20 @@ class Guacamole:
             url_params=params,
         )
 
+    def get_connection_group_connections(
+        self, connection_group_id, datasource=None
+    ):
+        """Get a list of connections linked to an organizational or balancing
+        connection group"""
+        if not datasource:
+            datasource = self.primary_datasource
+        return self.__auth_request(
+            method="GET",
+            url="{}/session/data/{}/connectionGroups/{}/tree".format(
+                self.REST_API, datasource, connection_group_id
+            ),
+        )
+
     def get_active_connections(self, datasource=None):
         if not datasource:
             datasource = self.primary_datasource


### PR DESCRIPTION
as exposed by:
https://github.com/apache/guacamole-client/blob/d1e928bea79ca81c827e9b6adedabc98eefdf701/guacamole/src/main/java/org/apache/guacamole/rest/connectiongroup/ConnectionGroupTree.java#L351

Note: I didn't pass any `url_params` to the `request`. According to the [above mentioned code](https://github.com/apache/guacamole-client/blob/d1e928bea79ca81c827e9b6adedabc98eefdf701/guacamole/src/main/java/org/apache/guacamole/rest/connectiongroup/ConnectionGroupTree.java#L344), this lists all visible connections. I hope it's ok!