### PR TITLE
doc: fix inaccurate comment in method docstring

### DIFF
--- a/guacapy/client.py
+++ b/guacapy/client.py
@@ -193,7 +193,7 @@ class Guacamole:
 
     def get_connection_by_name(self, name, regex=False, datasource=None):
         """
-        Get a connection group by its name
+        Get a connection by its name
         """
         cons = self.get_connections(datasource)
         res = self.__get_connection_by_name(cons, name, regex)


### PR DESCRIPTION
Minor change, but removes confusion with the other Python method proposed in #47. :)