### PR TITLE
fix: double / in request URL

### DIFF
--- a/guacapy/client.py
+++ b/guacapy/client.py
@@ -48,7 +48,7 @@ class Guacamole:
             raise ValueError("Only http and https methods are valid.")
         if not url_path:
             url_path = "/"
-        self.REST_API = "{}://{}{}/api".format(method, hostname, url_path)
+        self.REST_API = "{}://{}{}api".format(method, hostname, url_path)
         self.username = username
         self.password = password
         self.secret = secret


### PR DESCRIPTION
url_path handles this anyways with the default / value. The other option is adding in a variable to just skip url_path entirely.