### PR TITLE
totp token string with 6 digit zero padded : Fixes pschmitt/guacapy#69

### DIFF
--- a/guacapy/client.py
+++ b/guacapy/client.py
@@ -28,7 +28,8 @@ def get_hotp_token(secret, intervals_no):
 
 
 def get_totp_token(secret):
-    return get_hotp_token(secret, intervals_no=int(time.time()) // 30)
+    value = get_hotp_token(secret, intervals_no=int(time.time()) // 30)
+    return str(value).rjust(6, '0') # 6 digits for totp token (pad with 0 char)
 
 
 class Guacamole:

--- a/guacapy/client.py
+++ b/guacapy/client.py
@@ -29,7 +29,8 @@ def get_hotp_token(secret, intervals_no):
 
 def get_totp_token(secret):
     value = get_hotp_token(secret, intervals_no=int(time.time()) // 30)
-    return str(value).rjust(6, '0') # 6 digits for totp token (pad with 0 char)
+    # 6 digits for totp token (pad with 0 char)
+    return str(value).rjust(6, "0")
 
 
 class Guacamole:


### PR DESCRIPTION
The totp token consists of 6 digits and when the totp code computed by the method get_hotp_token is < 100000, the int value don't have 6 digits and the method get_totp_token return a bad token.
So i changed the get_totp_token at my business work like this :

def get_totp_token(secret):
    value = get_hotp_token(secret, intervals_no=int(time.time()) // 30)
    return str(value).rjust(6, '0') # 6 digits for totp token (pad with 0 char)

Edit by pschmitt: Closes #69